### PR TITLE
Add HCL parsing enhancements with python-hcl2

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Lint
         run: |
           pip install ruff
-          ruff --output-format=github .
+          ruff check --output-format=github .
         continue-on-error: true
       - name: Run Tests
         run: |
@@ -42,6 +42,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.release.tag_name }}
     - name: Set up Python
       uses: actions/setup-python@v3
       with:
@@ -51,12 +53,14 @@ jobs:
         python -m pip install --upgrade pip
         pip install build
     - name: Bump version
+      env:
+        TAG_NAME: ${{ github.event.release.tag_name }}
       run: |
-        VERSION=$(echo $GITHUB_REF | sed 's#.*/v##')
+        VERSION="${TAG_NAME#v}"
         PLACEHOLDER='__version__ = "0.1.dev1"'
         VERSION_FILE='src/tfdocs/version.py'
-        grep "$PLACEHOLDER" "$VERSION_FILE"
-        sed -i "s/$PLACEHOLDER/__version__ = \"${VERSION}\"/g" "$VERSION_FILE"
+        grep -F "$PLACEHOLDER" "$VERSION_FILE"
+        sed -i "s|$PLACEHOLDER|__version__ = \"${VERSION}\"|g" "$VERSION_FILE"
       shell: bash
     - name: Build package
       run: python -m build

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -16,9 +16,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: '3.9'
       - name: Install dependencies
@@ -41,11 +41,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         ref: ${{ github.event.release.tag_name }}
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: '3.9'
     - name: Install dependencies

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "python.testing.pytestArgs": [
+        "tests"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,8 @@ name = "tfdocs"
 
 dependencies = [
     "rich>=12.0.0",
-    "GitPython>=3.1.30"
+    "GitPython>=3.1.30",
+    "python-hcl2>=8.0.0",
 ]
 
 dynamic = ["version"]

--- a/src/tfdocs/readme.py
+++ b/src/tfdocs/readme.py
@@ -9,6 +9,7 @@ from rich.console import Console
 from tfdocs.utils import (
     construct_validation_blocks,
     construct_tf_file,
+    extract_default_blocks,
     extract_type_overrides,
     extract_validation_blocks,
     generate_source,
@@ -52,6 +53,7 @@ class Readme:
                 file_content = file.read().strip()
             parsed_content = hcl2.load(StringIO(file_content))
             type_overrides = extract_type_overrides(file_content)
+            self.default_blocks = extract_default_blocks(file_content)
             validation_blocks = extract_validation_blocks(file_content)
 
             for variable_block in parsed_content.get("variable", []):
@@ -102,7 +104,7 @@ class Readme:
                 self.variables, key=lambda k: k["name"]
             )
 
-            if construct_tf_file(self.sorted_variables).strip() == file_content.strip():
+            if construct_tf_file(self.sorted_variables, self.default_blocks).strip() == file_content.strip():
                 self.variables_changed = False
 
         except FileNotFoundError:
@@ -113,11 +115,11 @@ class Readme:
 
     def write_variables(self) -> None:
         with open(self.variables_file, "w") as file:
-            file.writelines(construct_tf_file(self.sorted_variables))
+            file.writelines(construct_tf_file(self.sorted_variables, self.default_blocks))
 
     def print_variables_file(self) -> None:
         self.console.print("[purple]--- variables.tf ---[/]")
-        print(construct_tf_file(self.sorted_variables))
+        print(construct_tf_file(self.sorted_variables, self.default_blocks))
 
     def get_status(self) -> Dict[str, bool]:
         return {

--- a/src/tfdocs/readme.py
+++ b/src/tfdocs/readme.py
@@ -15,6 +15,7 @@ from tfdocs.utils import (
     generate_source,
     hcl_value_to_string,
     normalize_hcl_string,
+    normalize_inline_spacing,
 )
 
 
@@ -67,9 +68,11 @@ class Readme:
                         body = {}
 
                     type_override = type_overrides.get(name)
-                    type_content = hcl_value_to_string(
-                        body.get("type", "unknown"),
-                        treat_plain_string_as_expression=True,
+                    type_content = normalize_inline_spacing(
+                        hcl_value_to_string(
+                            body.get("type", "unknown"),
+                            treat_plain_string_as_expression=True,
+                        ).strip()
                     )
                     description_raw = body.get("description")
                     description_content = (

--- a/src/tfdocs/readme.py
+++ b/src/tfdocs/readme.py
@@ -10,12 +10,12 @@ from tfdocs.utils import (
     construct_validation_blocks,
     construct_tf_file,
     extract_default_blocks,
+    extract_type_blocks,
     extract_type_overrides,
     extract_validation_blocks,
     generate_source,
     hcl_value_to_string,
     normalize_hcl_string,
-    normalize_inline_spacing,
 )
 
 
@@ -53,6 +53,7 @@ class Readme:
             with open(self.variables_file, "r") as file:
                 file_content = file.read().strip()
             parsed_content = hcl2.load(StringIO(file_content))
+            self.type_blocks = extract_type_blocks(file_content)
             type_overrides = extract_type_overrides(file_content)
             self.default_blocks = extract_default_blocks(file_content)
             validation_blocks = extract_validation_blocks(file_content)
@@ -68,12 +69,14 @@ class Readme:
                         body = {}
 
                     type_override = type_overrides.get(name)
-                    type_content = normalize_inline_spacing(
-                        hcl_value_to_string(
+                    raw_type_block = self.type_blocks.get(name, "")
+                    if raw_type_block and "\n" not in raw_type_block:
+                        type_content = raw_type_block.strip()
+                    else:
+                        type_content = hcl_value_to_string(
                             body.get("type", "unknown"),
                             treat_plain_string_as_expression=True,
                         ).strip()
-                    )
                     description_raw = body.get("description")
                     description_content = (
                         hcl_value_to_string(description_raw)
@@ -107,7 +110,11 @@ class Readme:
                 self.variables, key=lambda k: k["name"]
             )
 
-            if construct_tf_file(self.sorted_variables, self.default_blocks).strip() == file_content.strip():
+            if construct_tf_file(
+                self.sorted_variables,
+                self.default_blocks,
+                self.type_blocks,
+            ).strip() == file_content.strip():
                 self.variables_changed = False
 
         except FileNotFoundError:
@@ -118,11 +125,23 @@ class Readme:
 
     def write_variables(self) -> None:
         with open(self.variables_file, "w") as file:
-            file.writelines(construct_tf_file(self.sorted_variables, self.default_blocks))
+            file.writelines(
+                construct_tf_file(
+                    self.sorted_variables,
+                    self.default_blocks,
+                    self.type_blocks,
+                )
+            )
 
     def print_variables_file(self) -> None:
         self.console.print("[purple]--- variables.tf ---[/]")
-        print(construct_tf_file(self.sorted_variables, self.default_blocks))
+        print(
+            construct_tf_file(
+                self.sorted_variables,
+                self.default_blocks,
+                self.type_blocks,
+            )
+        )
 
     def get_status(self) -> Dict[str, bool]:
         return {

--- a/src/tfdocs/readme.py
+++ b/src/tfdocs/readme.py
@@ -10,8 +10,10 @@ from tfdocs.utils import (
     construct_validation_blocks,
     construct_tf_file,
     extract_type_overrides,
+    extract_validation_blocks,
     generate_source,
     hcl_value_to_string,
+    normalize_hcl_string,
 )
 
 
@@ -50,12 +52,15 @@ class Readme:
                 file_content = file.read().strip()
             parsed_content = hcl2.load(StringIO(file_content))
             type_overrides = extract_type_overrides(file_content)
+            validation_blocks = extract_validation_blocks(file_content)
 
             for variable_block in parsed_content.get("variable", []):
                 if not isinstance(variable_block, dict):
                     continue
 
                 for name, body in variable_block.items():
+                    if isinstance(name, str):
+                        name = normalize_hcl_string(name)
                     if not isinstance(body, dict):
                         body = {}
 
@@ -70,7 +75,7 @@ class Readme:
                         if description_raw is not None
                         else '"No description provided"'
                     )
-                    validation_content = construct_validation_blocks(
+                    validation_content = validation_blocks.get(name) or construct_validation_blocks(
                         body.get("validation")
                     )
 

--- a/src/tfdocs/readme.py
+++ b/src/tfdocs/readme.py
@@ -1,16 +1,17 @@
 import os
-import re
 import sys
+from io import StringIO
 from typing import List, Dict, Optional, TypedDict
 
+import hcl2
 from rich.console import Console
 
 from tfdocs.utils import (
-    count_blocks,
+    construct_validation_blocks,
     construct_tf_file,
+    extract_type_overrides,
     generate_source,
-    process_line_block,
-    process_named_block,
+    hcl_value_to_string,
 )
 
 
@@ -24,8 +25,6 @@ class VariableItem(TypedDict, total=False):
 
 
 class Readme:
-    _re_var_header = re.compile(r'\s*variable\s+"?(\w+)"?\s*{\s*', re.DOTALL)
-
     def __init__(
         self,
         readme_file: str,
@@ -49,81 +48,46 @@ class Readme:
         try:
             with open(self.variables_file, "r") as file:
                 file_content = file.read().strip()
+            parsed_content = hcl2.load(StringIO(file_content))
+            type_overrides = extract_type_overrides(file_content)
 
-            block: List[str] = []
-            match_flag = False
-            name: Optional[str] = None
+            for variable_block in parsed_content.get("variable", []):
+                if not isinstance(variable_block, dict):
+                    continue
 
-            for line in file_content.split("\n"):
-                block.append(line)
-                match = self._re_var_header.match(line)
-                if match and not match_flag:
-                    name = match.group(1)
-                    match_flag = True
+                for name, body in variable_block.items():
+                    if not isinstance(body, dict):
+                        body = {}
 
-                if count_blocks(block) and match_flag:
-                    match_flag = False
-                    (
-                        type_content,
-                        default_content,
-                        description_content,
-                        type_override,
-                        validation_content,
-                    ) = ("", "", "", None, "")
-                    type_cont = None
-                    type_override_cont = None
-                    default_cont = None
-                    description_cont = None
-                    validation_cont = None
+                    type_override = type_overrides.get(name)
+                    type_content = hcl_value_to_string(
+                        body.get("type", "unknown"),
+                        treat_plain_string_as_expression=True,
+                    )
+                    description_raw = body.get("description")
+                    description_content = (
+                        hcl_value_to_string(description_raw)
+                        if description_raw is not None
+                        else '"No description provided"'
+                    )
+                    validation_content = construct_validation_blocks(
+                        body.get("validation")
+                    )
 
-                    for line_block in block:
-                        type_content, type_cont = process_line_block(
-                            line_block, "type", type_content, type_cont
-                        )
+                    type_len_content = type_override if type_override else type_content
+                    candidate_len = len(f"  {name} = <{type_len_content}>")
+                    if candidate_len > self.str_len:
+                        self.str_len = candidate_len
 
-                        type_override, type_override_cont = process_line_block(
-                            line_block,
-                            "type_override",
-                            type_override,
-                            type_override_cont,
-                        )
-
-                        type_len_content = (
-                            type_override if type_override else type_content
-                        )
-                        if name and type_len_content:
-                            candidate_len = len(f"  {name} = <{type_len_content}>")
-                            if candidate_len > self.str_len:
-                                self.str_len = candidate_len
-
-                        default_content, default_cont = process_line_block(
-                            line_block, "default", default_content, default_cont
-                        )
-                        description_content, description_cont = process_line_block(
-                            line_block,
-                            "description",
-                            description_content,
-                            description_cont,
-                        )
-                        validation_content, validation_cont = process_named_block(
-                            line_block,
-                            "validation",
-                            validation_content,
-                            validation_cont,
-                        )
-
-                    block = []
                     attributes: VariableItem = {
-                        "name": name or "",
+                        "name": name,
                         "type_override": type_override,
                         "type": type_content if type_content else "unknown",
-                        "description": description_content
-                        if description_content
-                        else '"No description provided"',
+                        "description": description_content,
                     }
 
-                    if default_content:
-                        attributes["default"] = default_content
+                    if "default" in body:
+                        attributes["default"] = hcl_value_to_string(body["default"])
                     if validation_content:
                         attributes["validation"] = validation_content
 

--- a/src/tfdocs/utils.py
+++ b/src/tfdocs/utils.py
@@ -1,5 +1,6 @@
 import os
 import re
+import json
 import git
 
 
@@ -74,6 +75,9 @@ def process_named_block(line_block, target_type, content, cont):
             cont = None
 
     return content, cont
+
+
+_RE_VAR_HEADER = re.compile(r'\s*variable\s+"?([^"]+)"?\s*{\s*', re.DOTALL)
 
 
 _TYPE_CONSTRUCTORS_RE = re.compile(r"\b(list|set|map|object|tuple)\b")
@@ -227,6 +231,125 @@ def indent_block(content: str, indent_level: int = 0) -> str:
         f"{indent}{line[common_indent:]}" if line.strip() else ""
         for line in lines
     )
+
+
+def _is_expression_string(value: str) -> bool:
+    stripped = value.strip()
+    return stripped.startswith("${") and stripped.endswith("}")
+
+
+def _unwrap_expression(value: str) -> str:
+    stripped = value.strip()
+    return stripped[2:-1] if _is_expression_string(stripped) else stripped
+
+
+def _format_hcl_key(key) -> str:
+    if isinstance(key, str):
+        return json.dumps(key)
+    return str(key)
+
+
+def hcl_value_to_string(value, treat_plain_string_as_expression: bool = False) -> str:
+    if value is None:
+        return "null"
+
+    if isinstance(value, bool):
+        return "true" if value else "false"
+
+    if isinstance(value, (int, float)):
+        return str(value)
+
+    if isinstance(value, str):
+        if _is_expression_string(value):
+            return _unwrap_expression(value)
+        if treat_plain_string_as_expression:
+            return value.strip()
+        return json.dumps(value)
+
+    if isinstance(value, list):
+        return "[" + ",".join(hcl_value_to_string(item) for item in value) + "]"
+
+    if isinstance(value, dict):
+        parts = [
+            f"{_format_hcl_key(key)} = {hcl_value_to_string(item)}"
+            for key, item in value.items()
+        ]
+        return "{" + ",".join(parts) + "}"
+
+    return str(value)
+
+
+def construct_validation_blocks(validation_value) -> str:
+    if not validation_value:
+        return ""
+
+    validation_blocks = (
+        validation_value
+        if isinstance(validation_value, list)
+        else [validation_value]
+    )
+
+    rendered_blocks = []
+    for block in validation_blocks:
+        if not isinstance(block, dict):
+            continue
+
+        lines = ["  validation {"]
+        if "condition" in block:
+            lines.append(
+                "    condition = "
+                + hcl_value_to_string(
+                    block["condition"], treat_plain_string_as_expression=True
+                )
+            )
+        if "error_message" in block:
+            lines.append(
+                "    error_message = " + hcl_value_to_string(block["error_message"])
+            )
+
+        for key, value in block.items():
+            if key in {"condition", "error_message"}:
+                continue
+            lines.append(f"    {key} = {hcl_value_to_string(value)}")
+
+        lines.append("  }")
+        rendered_blocks.append("\n".join(lines))
+
+    return "\n".join(rendered_blocks)
+
+
+def extract_type_overrides(file_content: str) -> dict[str, str]:
+    overrides: dict[str, str] = {}
+    block = []
+    match_flag = False
+    name = None
+
+    for line in file_content.split("\n"):
+        block.append(line)
+        match = _RE_VAR_HEADER.match(line)
+        if match and not match_flag:
+            name = match.group(1)
+            match_flag = True
+
+        if count_blocks(block) and match_flag:
+            match_flag = False
+            type_override = None
+            cont = None
+
+            for line_block in block:
+                type_override, cont = process_line_block(
+                    line_block,
+                    "type_override",
+                    type_override,
+                    cont,
+                )
+
+            if name and type_override:
+                overrides[name] = type_override
+
+            block = []
+
+    return overrides
 
 
 def construct_tf_variable(content):

--- a/src/tfdocs/utils.py
+++ b/src/tfdocs/utils.py
@@ -249,6 +249,18 @@ def _format_hcl_key(key) -> str:
     return str(key)
 
 
+def normalize_hcl_string(value: str) -> str:
+    stripped = value.strip()
+    if len(stripped) >= 2 and stripped[0] == stripped[-1] and stripped[0] in {'"', "'"}:
+        if stripped[0] == '"':
+            try:
+                return json.loads(stripped)
+            except json.JSONDecodeError:
+                return stripped[1:-1]
+        return stripped[1:-1]
+    return value
+
+
 def hcl_value_to_string(value, treat_plain_string_as_expression: bool = False) -> str:
     if value is None:
         return "null"
@@ -260,6 +272,7 @@ def hcl_value_to_string(value, treat_plain_string_as_expression: bool = False) -
         return str(value)
 
     if isinstance(value, str):
+        value = normalize_hcl_string(value)
         if _is_expression_string(value):
             return _unwrap_expression(value)
         if treat_plain_string_as_expression:
@@ -320,6 +333,28 @@ def construct_validation_blocks(validation_value) -> str:
 
 def extract_type_overrides(file_content: str) -> dict[str, str]:
     overrides: dict[str, str] = {}
+    metadata = extract_variable_metadata(file_content)
+    for name, item in metadata.items():
+        type_override = item.get("type_override")
+        if type_override:
+            overrides[name] = type_override
+
+    return overrides
+
+
+def extract_validation_blocks(file_content: str) -> dict[str, str]:
+    validations: dict[str, str] = {}
+    metadata = extract_variable_metadata(file_content)
+    for name, item in metadata.items():
+        validation = item.get("validation")
+        if validation:
+            validations[name] = validation
+
+    return validations
+
+
+def extract_variable_metadata(file_content: str) -> dict[str, dict[str, str]]:
+    metadata: dict[str, dict[str, str]] = {}
     block = []
     match_flag = False
     name = None
@@ -334,22 +369,36 @@ def extract_type_overrides(file_content: str) -> dict[str, str]:
         if count_blocks(block) and match_flag:
             match_flag = False
             type_override = None
-            cont = None
+            type_override_cont = None
+            validation = ""
+            validation_cont = None
 
             for line_block in block:
-                type_override, cont = process_line_block(
+                type_override, type_override_cont = process_line_block(
                     line_block,
                     "type_override",
                     type_override,
-                    cont,
+                    type_override_cont,
+                )
+                validation, validation_cont = process_named_block(
+                    line_block,
+                    "validation",
+                    validation,
+                    validation_cont,
                 )
 
-            if name and type_override:
-                overrides[name] = type_override
+            if name:
+                item: dict[str, str] = {}
+                if type_override:
+                    item["type_override"] = type_override
+                if validation:
+                    item["validation"] = validation
+                if item:
+                    metadata[name] = item
 
             block = []
 
-    return overrides
+    return metadata
 
 
 def construct_tf_variable(content):

--- a/src/tfdocs/utils.py
+++ b/src/tfdocs/utils.py
@@ -285,10 +285,6 @@ def normalize_hcl_string(value: str) -> str:
     return value
 
 
-def normalize_inline_spacing(value: str) -> str:
-    return re.sub(r",(?!\s)", ", ", value)
-
-
 def hcl_value_to_string(value, treat_plain_string_as_expression: bool = False) -> str:
     if value is None:
         return "null"
@@ -370,6 +366,17 @@ def extract_type_overrides(file_content: str) -> dict[str, str]:
     return overrides
 
 
+def extract_type_blocks(file_content: str) -> dict[str, str]:
+    type_blocks: dict[str, str] = {}
+    metadata = extract_variable_metadata(file_content)
+    for name, item in metadata.items():
+        type_block = item.get("type_block")
+        if type_block is not None:
+            type_blocks[name] = type_block
+
+    return type_blocks
+
+
 def extract_validation_blocks(file_content: str) -> dict[str, str]:
     validations: dict[str, str] = {}
     metadata = extract_variable_metadata(file_content)
@@ -407,6 +414,8 @@ def extract_variable_metadata(file_content: str) -> dict[str, dict[str, str]]:
 
         if count_blocks(block) and match_flag:
             match_flag = False
+            type_block = ""
+            type_block_cont = None
             type_override = None
             type_override_cont = None
             default_block = ""
@@ -415,6 +424,12 @@ def extract_variable_metadata(file_content: str) -> dict[str, dict[str, str]]:
             validation_cont = None
 
             for line_block in block:
+                type_block, type_block_cont = process_raw_assignment_block(
+                    line_block,
+                    "type",
+                    type_block,
+                    type_block_cont,
+                )
                 type_override, type_override_cont = process_line_block(
                     line_block,
                     "type_override",
@@ -436,6 +451,8 @@ def extract_variable_metadata(file_content: str) -> dict[str, dict[str, str]]:
 
             if name:
                 item: dict[str, str] = {}
+                if type_block:
+                    item["type_block"] = type_block
                 if type_override:
                     item["type_override"] = type_override
                 if default_block:
@@ -450,9 +467,14 @@ def extract_variable_metadata(file_content: str) -> dict[str, dict[str, str]]:
     return metadata
 
 
-def construct_tf_variable(content, default_blocks: dict[str, str] | None = None):
+def construct_tf_variable(
+    content,
+    default_blocks: dict[str, str] | None = None,
+    type_blocks: dict[str, str] | None = None,
+):
     name = content["name"]
     type_str = content["type"].strip()
+    type_block_str = (type_blocks or {}).get(name, "").strip()
     desc_str = content["description"].strip()
     has_default = "default" in content
     default_str = content.get("default", "").strip()
@@ -468,9 +490,19 @@ def construct_tf_variable(content, default_blocks: dict[str, str] | None = None)
 
     if desc_first:
         lines.append(f"  description = {desc_str}")
-        lines.append(f"  type = {format_block(type_str, inline=True)}")
+        if type_block_str:
+            type_lines = type_block_str.splitlines()
+            lines.append(f"  type = {type_lines[0].strip()}")
+            lines.extend(line.rstrip() for line in type_lines[1:])
+        else:
+            lines.append(f"  type = {format_block(type_str, inline=True)}")
     else:
-        lines.append(f"  type = {format_block(type_str, inline=True)}")
+        if type_block_str:
+            type_lines = type_block_str.splitlines()
+            lines.append(f"  type = {type_lines[0].strip()}")
+            lines.extend(line.rstrip() for line in type_lines[1:])
+        else:
+            lines.append(f"  type = {format_block(type_str, inline=True)}")
         lines.append(f"  description = {desc_str}")
 
     if has_default:
@@ -493,8 +525,19 @@ def construct_tf_variable(content, default_blocks: dict[str, str] | None = None)
     return "\n".join(lines)
 
 
-def construct_tf_file(content, default_blocks: dict[str, str] | None = None):
-    parts = (construct_tf_variable(item, default_blocks=default_blocks) for item in content)
+def construct_tf_file(
+    content,
+    default_blocks: dict[str, str] | None = None,
+    type_blocks: dict[str, str] | None = None,
+):
+    parts = (
+        construct_tf_variable(
+            item,
+            default_blocks=default_blocks,
+            type_blocks=type_blocks,
+        )
+        for item in content
+    )
     return "".join(parts).rstrip() + "\n"
 
 

--- a/src/tfdocs/utils.py
+++ b/src/tfdocs/utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import re
 import json
@@ -44,6 +46,28 @@ def process_line_block(line_block, target_type, content, cont):
     if type_match or cont == target_type:
         if cont:
             content += line_block.strip()
+        else:
+            content = line_block.split("=", 1)[1].strip()
+
+        if not count_blocks(content):
+            cont = target_type
+        else:
+            cont = None
+
+    return content, cont
+
+
+def process_raw_assignment_block(line_block, target_type, content, cont):
+    type_match = None
+
+    if not cont:
+        type_match = (
+            line_block if re.match(rf"^\s*{target_type}\s*=\s*", line_block) else None
+        )
+
+    if type_match or cont == target_type:
+        if cont and content:
+            content += "\n" + line_block.rstrip()
         else:
             content = line_block.split("=", 1)[1].strip()
 
@@ -353,6 +377,17 @@ def extract_validation_blocks(file_content: str) -> dict[str, str]:
     return validations
 
 
+def extract_default_blocks(file_content: str) -> dict[str, str]:
+    defaults: dict[str, str] = {}
+    metadata = extract_variable_metadata(file_content)
+    for name, item in metadata.items():
+        default = item.get("default_block")
+        if default is not None:
+            defaults[name] = default
+
+    return defaults
+
+
 def extract_variable_metadata(file_content: str) -> dict[str, dict[str, str]]:
     metadata: dict[str, dict[str, str]] = {}
     block = []
@@ -370,6 +405,8 @@ def extract_variable_metadata(file_content: str) -> dict[str, dict[str, str]]:
             match_flag = False
             type_override = None
             type_override_cont = None
+            default_block = ""
+            default_block_cont = None
             validation = ""
             validation_cont = None
 
@@ -379,6 +416,12 @@ def extract_variable_metadata(file_content: str) -> dict[str, dict[str, str]]:
                     "type_override",
                     type_override,
                     type_override_cont,
+                )
+                default_block, default_block_cont = process_raw_assignment_block(
+                    line_block,
+                    "default",
+                    default_block,
+                    default_block_cont,
                 )
                 validation, validation_cont = process_named_block(
                     line_block,
@@ -391,6 +434,8 @@ def extract_variable_metadata(file_content: str) -> dict[str, dict[str, str]]:
                 item: dict[str, str] = {}
                 if type_override:
                     item["type_override"] = type_override
+                if default_block:
+                    item["default_block"] = default_block
                 if validation:
                     item["validation"] = validation
                 if item:
@@ -401,12 +446,13 @@ def extract_variable_metadata(file_content: str) -> dict[str, dict[str, str]]:
     return metadata
 
 
-def construct_tf_variable(content):
+def construct_tf_variable(content, default_blocks: dict[str, str] | None = None):
     name = content["name"]
     type_str = content["type"].strip()
     desc_str = content["description"].strip()
     has_default = "default" in content
     default_str = content.get("default", "").strip()
+    default_block_str = (default_blocks or {}).get(name, "").strip()
     validation_str = content.get("validation", "")
 
     lines = [f'variable "{name}" {{']
@@ -424,7 +470,14 @@ def construct_tf_variable(content):
         lines.append(f"  description = {desc_str}")
 
     if has_default:
-        if default_str == "{}":
+        if default_block_str:
+            default_lines = default_block_str.splitlines()
+            if len(default_lines) == 1:
+                lines.append(f"  default = {default_lines[0].strip()}")
+            else:
+                lines.append(f"  default = {default_lines[0].strip()}")
+                lines.extend(line.rstrip() for line in default_lines[1:])
+        elif default_str == "{}":
             lines.append("  default = {}")
         else:
             lines.append(f"  default = {format_block(default_str, inline=True)}")
@@ -436,8 +489,8 @@ def construct_tf_variable(content):
     return "\n".join(lines)
 
 
-def construct_tf_file(content):
-    parts = (construct_tf_variable(item) for item in content)
+def construct_tf_file(content, default_blocks: dict[str, str] | None = None):
+    parts = (construct_tf_variable(item, default_blocks=default_blocks) for item in content)
     return "".join(parts).rstrip() + "\n"
 
 

--- a/src/tfdocs/utils.py
+++ b/src/tfdocs/utils.py
@@ -285,6 +285,10 @@ def normalize_hcl_string(value: str) -> str:
     return value
 
 
+def normalize_inline_spacing(value: str) -> str:
+    return re.sub(r",(?!\s)", ", ", value)
+
+
 def hcl_value_to_string(value, treat_plain_string_as_expression: bool = False) -> str:
     if value is None:
         return "null"

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -1,4 +1,3 @@
-import pytest
 from tfdocs.cli import get_parser, Options, get_version
 
 

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -1,10 +1,7 @@
-import os
-import sys
 import errno
 from unittest.mock import patch, MagicMock
 
 import pytest
-from rich.console import Console
 
 from tfdocs.__main__ import main, report_and_exit, _cli_entrypoint
 

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -31,6 +31,21 @@ def test_main_dry_run_with_format(mock_readme):
 
 
 @patch("tfdocs.readme.Readme")
+def test_main_dry_run_with_format_and_no_variable_changes(mock_readme):
+    """Test dry-run+format branch when variables.tf is already formatted."""
+    mock_instance = MagicMock()
+    mock_instance.get_status.return_value = {"variables": False, "readme": True}
+    mock_readme.return_value = mock_instance
+
+    with pytest.raises(SystemExit) as exc_info:
+        main(["tfdocs", "--dry-run", "-f"])
+    assert exc_info.value.code == -1
+
+    mock_instance.print_variables_file.assert_called_once()
+    mock_instance.print_readme.assert_called_once()
+
+
+@patch("tfdocs.readme.Readme")
 def test_main_dry_run_without_format(mock_readme):
     """Test main function with dry-run flag only."""
     mock_instance = MagicMock()

--- a/tests/readme_test.py
+++ b/tests/readme_test.py
@@ -267,62 +267,6 @@ variable "service_users" {
   }
 }
 """
-    expected_output = """
-variable "service_extra_users" {
-  type = map(object({
-    tags = list(string),
-    vhosts = list(string)
-  }))
-  description = "Extra users"
-  default = {
-    "monitor" = {
-      tags = [
-        "monitoring"
-      ]
-      vhosts = [
-        "imw",
-        "papi",
-        "capi",
-        "webhooks"
-      ]
-    }
-  }
-}
-
-variable "service_users" {
-  type = map(object({
-    tags = list(string),
-    vhosts = list(string)
-  }))
-  description = "Users"
-  default = {
-    "public-api" = {
-      tags = [
-        "administrator"
-      ]
-      vhosts = [
-        "papi"
-      ]
-    }
-    "integrations" = {
-      tags = [
-        "administrator"
-      ]
-      vhosts = [
-        "imw"
-      ]
-    }
-    "webhooks" = {
-      tags = [
-        "administrator"
-      ]
-      vhosts = [
-        "webhooks"
-      ]
-    }
-  }
-}
-"""
 
     with tempfile.TemporaryDirectory() as temp_dir:
         variables_file = os.path.join(temp_dir, "variables.tf")
@@ -342,17 +286,20 @@ variable "service_users" {
 
         assert '\\"monitor\\"' not in content
         assert '"tags" =' not in content
-        assert content.strip() == expected_output.strip()
+        assert content.strip() == variables_with_nested_map_defaults.strip()
 
 
-def test_object_type_spacing_in_readme_output():
+def test_inline_object_type_spacing_is_preserved_in_readme_output():
     variables_content = """
-variable "service_users" {
-  type = map(object({
-    tags = list(string)
-    vhosts = list(string)
-  }))
-  description = "Users"
+variable "service_users_compact" {
+  type = map(object({authorizations = map(list(string)),name = string}))
+  description = "Users compact"
+  default = {}
+}
+
+variable "service_users_spaced" {
+  type = map(object({tags = list(string), vhosts = list(string)}))
+  description = "Users spaced"
   default = {}
 }
 """
@@ -369,9 +316,15 @@ variable "service_users" {
 
         rd = readme.Readme(readme_file, variables_file, module_name="example")
 
-        assert rd.variables[0]["type"] == 'map(object({tags = list(string), vhosts = list(string)}))'
+        assert rd.variables[0]["type"] == 'map(object({authorizations = map(list(string)),name = string}))'
+        assert rd.variables[1]["type"] == 'map(object({tags = list(string), vhosts = list(string)}))'
         assert any(
-            'service_users = <MAP(OBJECT({TAGS = LIST(STRING), VHOSTS = LIST(STRING)}))>'
+            'service_users_compact = <MAP(OBJECT({AUTHORIZATIONS = MAP(LIST(STRING)),NAME = STRING}))>'
+            in line
+            for line in rd.construct_readme()
+        )
+        assert any(
+            'service_users_spaced = <MAP(OBJECT({TAGS = LIST(STRING), VHOSTS = LIST(STRING)}))>'
             in line
             for line in rd.construct_readme()
         )

--- a/tests/readme_test.py
+++ b/tests/readme_test.py
@@ -163,6 +163,40 @@ def test_write_readme(temp_files):
     assert content.strip() == expected_readme_content.strip()
 
 
+def test_construct_readme_without_existing_readme():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        variables_file = os.path.join(temp_dir, "variables.tf")
+        readme_file = os.path.join(temp_dir, "README.md")
+
+        with open(variables_file, "w") as f:
+            f.write(mock_variables_tf)
+
+        rd = readme.Readme(
+            readme_file,
+            variables_file,
+            module_name="example",
+            module_source="git@git.com:tfdocs",
+        )
+
+        constructed_readme = rd.construct_readme()
+
+        assert constructed_readme[0] == "# example module"
+        assert "<!-- TFDOCS START -->" in constructed_readme
+        assert "<!-- TFDOCS END -->" in constructed_readme
+        assert '  source = "git@git.com:tfdocs"' in constructed_readme
+
+
+def test_readme_initialization_missing_variables_file():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        variables_file = os.path.join(temp_dir, "does-not-exist.tf")
+        readme_file = os.path.join(temp_dir, "README.md")
+
+        with pytest.raises(SystemExit) as exc_info:
+            readme.Readme(readme_file, variables_file)
+
+        assert exc_info.value.code == -1
+
+
 def test_validation_variable_round_trip():
     variable_with_validation = """
 variable "subnet_ids" {
@@ -328,3 +362,50 @@ variable "service_users_spaced" {
             in line
             for line in rd.construct_readme()
         )
+
+
+def test_type_block_round_trip_preserves_inline_spacing_styles():
+    variables_content = """
+variable "service_links_compact" {
+  type = map(object({authorizations = map(list(string)),name = string}))
+  description = "Links compact"
+  default = {}
+}
+
+variable "service_links_spaced" {
+  type = map(object({tags = list(string), vhosts = list(string)}))
+  description = "Links spaced"
+  default = {}
+}
+"""
+    expected_output = """
+variable "service_links_compact" {
+  description = "Links compact"
+  type = map(object({authorizations = map(list(string)),name = string}))
+  default = {}
+}
+
+variable "service_links_spaced" {
+  description = "Links spaced"
+  type = map(object({tags = list(string), vhosts = list(string)}))
+  default = {}
+}
+"""
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        variables_file = os.path.join(temp_dir, "variables.tf")
+        readme_file = os.path.join(temp_dir, "README.md")
+
+        with open(variables_file, "w") as f:
+            f.write(variables_content)
+
+        with open(readme_file, "w") as f:
+            f.write(mock_readme_md)
+
+        rd = readme.Readme(readme_file, variables_file)
+        rd.write_variables()
+
+        with open(variables_file, "r") as f:
+            content = f.read()
+
+        assert content.strip() == expected_output.strip()

--- a/tests/readme_test.py
+++ b/tests/readme_test.py
@@ -122,7 +122,9 @@ def test_write_variables(temp_files):
     with open(variables_file, "r") as f:
         content = f.read()
 
-    assert content.strip() == utils.construct_tf_file(rd.sorted_variables).strip()
+    assert content.strip() == utils.construct_tf_file(
+        rd.sorted_variables, rd.default_blocks
+    ).strip()
 
 def test_construct_readme(temp_files):
     variables_file, readme_file = temp_files
@@ -206,3 +208,138 @@ variable "subnet_ids" {
             content = f.read()
 
         assert content.strip() == variable_with_validation.strip()
+
+
+def test_nested_map_default_round_trip():
+    variables_with_nested_map_defaults = """
+variable "service_extra_users" {
+  type = map(object({
+    tags = list(string)
+    vhosts = list(string)
+  }))
+  description = "Extra users"
+  default = {
+    "monitor" = {
+      tags = [
+        "monitoring"
+      ]
+      vhosts = [
+        "imw",
+        "papi",
+        "capi",
+        "webhooks"
+      ]
+    }
+  }
+}
+
+variable "service_users" {
+  type = map(object({
+    tags = list(string)
+    vhosts = list(string)
+  }))
+  description = "Users"
+  default = {
+    "public-api" = {
+      tags = [
+        "administrator"
+      ]
+      vhosts = [
+        "papi"
+      ]
+    }
+    "integrations" = {
+      tags = [
+        "administrator"
+      ]
+      vhosts = [
+        "imw"
+      ]
+    }
+    "webhooks" = {
+      tags = [
+        "administrator"
+      ]
+      vhosts = [
+        "webhooks"
+      ]
+    }
+  }
+}
+"""
+    expected_output = """
+variable "service_extra_users" {
+  type = map(object({
+    tags = list(string),
+    vhosts = list(string)
+  }))
+  description = "Extra users"
+  default = {
+    "monitor" = {
+      tags = [
+        "monitoring"
+      ]
+      vhosts = [
+        "imw",
+        "papi",
+        "capi",
+        "webhooks"
+      ]
+    }
+  }
+}
+
+variable "service_users" {
+  type = map(object({
+    tags = list(string),
+    vhosts = list(string)
+  }))
+  description = "Users"
+  default = {
+    "public-api" = {
+      tags = [
+        "administrator"
+      ]
+      vhosts = [
+        "papi"
+      ]
+    }
+    "integrations" = {
+      tags = [
+        "administrator"
+      ]
+      vhosts = [
+        "imw"
+      ]
+    }
+    "webhooks" = {
+      tags = [
+        "administrator"
+      ]
+      vhosts = [
+        "webhooks"
+      ]
+    }
+  }
+}
+"""
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        variables_file = os.path.join(temp_dir, "variables.tf")
+        readme_file = os.path.join(temp_dir, "README.md")
+
+        with open(variables_file, "w") as f:
+            f.write(variables_with_nested_map_defaults)
+
+        with open(readme_file, "w") as f:
+            f.write(mock_readme_md)
+
+        rd = readme.Readme(readme_file, variables_file)
+        rd.write_variables()
+
+        with open(variables_file, "r") as f:
+            content = f.read()
+
+        assert '\\"monitor\\"' not in content
+        assert '"tags" =' not in content
+        assert content.strip() == expected_output.strip()

--- a/tests/readme_test.py
+++ b/tests/readme_test.py
@@ -343,3 +343,35 @@ variable "service_users" {
         assert '\\"monitor\\"' not in content
         assert '"tags" =' not in content
         assert content.strip() == expected_output.strip()
+
+
+def test_object_type_spacing_in_readme_output():
+    variables_content = """
+variable "service_users" {
+  type = map(object({
+    tags = list(string)
+    vhosts = list(string)
+  }))
+  description = "Users"
+  default = {}
+}
+"""
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        variables_file = os.path.join(temp_dir, "variables.tf")
+        readme_file = os.path.join(temp_dir, "README.md")
+
+        with open(variables_file, "w") as f:
+            f.write(variables_content)
+
+        with open(readme_file, "w") as f:
+            f.write(mock_readme_md)
+
+        rd = readme.Readme(readme_file, variables_file, module_name="example")
+
+        assert rd.variables[0]["type"] == 'map(object({tags = list(string), vhosts = list(string)}))'
+        assert any(
+            'service_users = <MAP(OBJECT({TAGS = LIST(STRING), VHOSTS = LIST(STRING)}))>'
+            in line
+            for line in rd.construct_readme()
+        )

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -124,6 +124,7 @@ def test_hcl_value_to_string():
     assert utils.hcl_value_to_string(False) == "false"
     assert utils.hcl_value_to_string(42) == "42"
     assert utils.hcl_value_to_string("plain text") == '"plain text"'
+    assert utils.hcl_value_to_string('"already quoted"') == '"already quoted"'
     assert (
         utils.hcl_value_to_string("${list(string)}", treat_plain_string_as_expression=True)
         == "list(string)"
@@ -159,6 +160,30 @@ variable "my_object" {
     assert utils.extract_type_overrides(content) == {
         "my_object": "list(object)"
     }
+
+
+def test_extract_validation_blocks():
+    content = """
+variable "subnet_ids" {
+  type = list(string)
+  validation {
+    condition = !(var.primary && !var.secondary) || (var.subnet_ids != null && length(var.subnet_ids) > 0)
+    error_message = "You must set subnet_ids when primary is true and secondary is false."
+  }
+}
+"""
+    assert utils.extract_validation_blocks(content) == {
+        "subnet_ids": """  validation {
+    condition = !(var.primary && !var.secondary) || (var.subnet_ids != null && length(var.subnet_ids) > 0)
+    error_message = "You must set subnet_ids when primary is true and secondary is false."
+  }"""
+    }
+
+
+def test_normalize_hcl_string():
+    assert utils.normalize_hcl_string('"var1"') == "var1"
+    assert utils.normalize_hcl_string('"This is variable 1"') == "This is variable 1"
+    assert utils.normalize_hcl_string("list(string)") == "list(string)"
 
 
 def test_match_type_constructors():

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -180,6 +180,31 @@ variable "subnet_ids" {
     }
 
 
+def test_extract_default_blocks():
+    content = """
+variable "rabbitmq_extra_users" {
+  type = map(object({
+    tags = list(string)
+    vhosts = list(string)
+  }))
+  default = {
+    "monitor" = {
+      tags = ["monitoring"]
+      vhosts = ["imw", "papi", "capi", "webhooks"]
+    }
+  }
+}
+"""
+    assert utils.extract_default_blocks(content) == {
+        "rabbitmq_extra_users": """{
+    "monitor" = {
+      tags = ["monitoring"]
+      vhosts = ["imw", "papi", "capi", "webhooks"]
+    }
+  }"""
+    }
+
+
 def test_normalize_hcl_string():
     assert utils.normalize_hcl_string('"var1"') == "var1"
     assert utils.normalize_hcl_string('"This is variable 1"') == "This is variable 1"

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -211,6 +211,15 @@ def test_normalize_hcl_string():
     assert utils.normalize_hcl_string("list(string)") == "list(string)"
 
 
+def test_normalize_inline_spacing():
+    assert (
+        utils.normalize_inline_spacing(
+            "map(object({tags = list(string),vhosts = list(string)}))"
+        )
+        == "map(object({tags = list(string), vhosts = list(string)}))"
+    )
+
+
 def test_match_type_constructors():
     assert utils.match_type_constructors("list") is True
     assert utils.match_type_constructors("set") is True

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -118,6 +118,49 @@ def test_process_named_block():
     )
 
 
+def test_hcl_value_to_string():
+    assert utils.hcl_value_to_string(None) == "null"
+    assert utils.hcl_value_to_string(True) == "true"
+    assert utils.hcl_value_to_string(False) == "false"
+    assert utils.hcl_value_to_string(42) == "42"
+    assert utils.hcl_value_to_string("plain text") == '"plain text"'
+    assert (
+        utils.hcl_value_to_string("${list(string)}", treat_plain_string_as_expression=True)
+        == "list(string)"
+    )
+    assert utils.hcl_value_to_string("list(string)", treat_plain_string_as_expression=True) == "list(string)"
+    assert utils.hcl_value_to_string(["a", 1, None]) == '["a",1,null]'
+    assert utils.hcl_value_to_string({"user1": ["tag1"]}) == '{"user1" = ["tag1"]}'
+
+
+def test_construct_validation_blocks():
+    validation = [
+        {
+            "condition": "${!(var.primary && !var.secondary) || (var.subnet_ids != null && length(var.subnet_ids) > 0)}",
+            "error_message": "You must set subnet_ids when primary is true and secondary is false.",
+        }
+    ]
+    expected = """  validation {
+    condition = !(var.primary && !var.secondary) || (var.subnet_ids != null && length(var.subnet_ids) > 0)
+    error_message = "You must set subnet_ids when primary is true and secondary is false."
+  }"""
+    assert utils.construct_validation_blocks(validation) == expected
+
+
+def test_extract_type_overrides():
+    content = """
+variable "my_object" {
+  # tfdocs: type = list(object)
+  type = list(object({
+    name = string
+  }))
+}
+"""
+    assert utils.extract_type_overrides(content) == {
+        "my_object": "list(object)"
+    }
+
+
 def test_match_type_constructors():
     assert utils.match_type_constructors("list") is True
     assert utils.match_type_constructors("set") is True

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -162,6 +162,28 @@ variable "my_object" {
     }
 
 
+def test_extract_type_blocks():
+    content = """
+variable "service_users_compact" {
+  type = map(object({authorizations = map(list(string)),name = string}))
+}
+
+variable "service_users_multiline" {
+  type = map(object({
+    tags = list(string)
+    vhosts = list(string)
+  }))
+}
+"""
+    assert utils.extract_type_blocks(content) == {
+        "service_users_compact": "map(object({authorizations = map(list(string)),name = string}))",
+        "service_users_multiline": """map(object({
+    tags = list(string)
+    vhosts = list(string)
+  }))""",
+    }
+
+
 def test_extract_validation_blocks():
     content = """
 variable "subnet_ids" {
@@ -209,15 +231,6 @@ def test_normalize_hcl_string():
     assert utils.normalize_hcl_string('"var1"') == "var1"
     assert utils.normalize_hcl_string('"This is variable 1"') == "This is variable 1"
     assert utils.normalize_hcl_string("list(string)") == "list(string)"
-
-
-def test_normalize_inline_spacing():
-    assert (
-        utils.normalize_inline_spacing(
-            "map(object({tags = list(string),vhosts = list(string)}))"
-        )
-        == "map(object({tags = list(string), vhosts = list(string)}))"
-    )
 
 
 def test_match_type_constructors():


### PR DESCRIPTION
Introduce the python-hcl2 dependency to improve HCL parsing capabilities. Refactor the README parsing logic to utilize the new library, and add utility functions for HCL value conversion and validation block construction. Include tests to verify the functionality of the new utilities.